### PR TITLE
(fix) Fix PHP 8.4 nullable parameter deprecation warnings - fixes #327

### DIFF
--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -201,7 +201,7 @@ trait Translatable
         return parent::getAttributeValue($source_field);
     }
 
-    public static function getTranslatableResources(string $path = null, array $ignore = []): array
+    public static function getTranslatableResources(?string $path = null, array $ignore = []): array
     {
         $path = $path ?? app_path('Nova');
         return self::getTranslatableClasses(
@@ -211,7 +211,7 @@ trait Translatable
         );
     }
 
-    public static function getTranslatableResourcesWithModels(string $path = null, array $ignore = []): array
+    public static function getTranslatableResourcesWithModels(?string $path = null, array $ignore = []): array
     {
         $path = $path ?? app_path('Nova');
         return self::getTranslatableClasses(
@@ -229,7 +229,7 @@ trait Translatable
         return array_flip(self::getTranslatableResourcesWithModels());
     }
 
-    public static function getTranslatableModels(string $path = null, array $ignore = []): array
+    public static function getTranslatableModels(?string $path = null, array $ignore = []): array
     {
         $path = $path ?? app_path('Models');
         return self::getTranslatableClasses(
@@ -239,7 +239,7 @@ trait Translatable
         );
     }
 
-    public static function getTranslatableClasses(string $path = null, array $ignore = [], ?string $uses = null, ?callable $add_callback = null): array
+    public static function getTranslatableClasses(?string $path = null, array $ignore = [], ?string $uses = null, ?callable $add_callback = null): array
     {
         $run_again_method = Arr::get(debug_backtrace(), '1.function');
 


### PR DESCRIPTION
## Summary
- Fixed PHP 8.4 deprecation warnings by explicitly marking nullable parameters with the ? prefix
- Updated 4 methods in the Translatable trait that had implicitly nullable $path parameters
- This resolves all 124 deprecation warnings reported in issue #327

## Changes
- Added explicit nullable type declaration (?) to the $path parameter in:
  - getTranslatableResources()
  - getTranslatableResourcesWithModels()
  - getTranslatableModels()
  - getTranslatableClasses()

## Test plan
- No existing tests in the repository
- Changes are backward compatible - only adding explicit nullable type declarations
- Tested that the methods still work with both null and string values for $path

Fixes #327