### PR TITLE
Replace eminiarts/tabs with Laravel Nova built-in tabs

### DIFF
--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -307,7 +307,7 @@ trait Translatable
             ->reject(fn($field) => $field instanceof LanguageToggler)
             ->reject(fn($field) => in_array(RelatableField::class, class_implements($field)))
             ->each(function ($field) use (&$translatable_columns) {
-                if (get_class($field) == 'Eminiarts\Tabs\Tabs') {
+                if (get_class($field) == 'Laravel\Nova\Tabs\TabsGroup') {
                     collect($field->data)
                         ->reject(fn($field) => in_array(RelatableField::class, class_implements($field)))
                         ->each(function ($tab_field) use (&$translatable_columns) {

--- a/src/Traits/TranslatableFields.php
+++ b/src/Traits/TranslatableFields.php
@@ -45,9 +45,6 @@ trait TranslatableFields
         $fields = $this->translatableFields($request);
 
         foreach ($fields as $key => $field) {
-            if (is_object($field) && get_class($field) == 'Eminiarts\Tabs\Tabs') {
-                continue;
-            }
 
             if (is_object($field) && get_class($field) == 'Laravel\Nova\Tabs\TabsGroup') {
                 $translatable_data_fields = [];

--- a/src/TranslatableTabs.php
+++ b/src/TranslatableTabs.php
@@ -4,7 +4,7 @@ namespace Marshmallow\Translatable;
 
 use Error;
 use App\Nova\Resource;
-use Eminiarts\Tabs\Tabs;
+use Laravel\Nova\Tabs\Tab;
 
 class TranslatableTabs
 {
@@ -23,10 +23,10 @@ class TranslatableTabs
         return $resource->weAreNotTranslating() || $this->noEditModeAvailable() || $this->createModeActive();
     }
 
-    public function make(Resource $resource, string $name, array $tabs): Tabs
+    public function make(Resource $resource, string $name, array $tabs)
     {
         if ($this->shouldLoadNormalTabs($resource)) {
-            return new Tabs($name, $tabs);
+            return $this->createTabGroup($name, $tabs);
         }
 
         foreach ($tabs as $tab_name => $fields) {
@@ -45,6 +45,17 @@ class TranslatableTabs
             }
         }
 
-        return new Tabs($name, $tabs);
+        return $this->createTabGroup($name, $tabs);
+    }
+
+    protected function createTabGroup(string $name, array $tabs)
+    {
+        $novaTabs = [];
+        
+        foreach ($tabs as $tabName => $fields) {
+            $novaTabs[] = Tab::make($tabName, $fields);
+        }
+
+        return Tab::group($name, $novaTabs);
     }
 }


### PR DESCRIPTION
## Summary
- Replace `Eminiarts\Tabs\Tabs` with Laravel Nova's built-in `Laravel\Nova\Tabs\Tab` functionality
- Update `TranslatableTabs.php` to use `Tab::group()` and `Tab::make()` methods
- Update trait references to check for `Laravel\Nova\Tabs\TabsGroup`
- Remove all references to deprecated eminiarts/tabs package

## Changes Made
- **TranslatableTabs.php**: Updated import and refactored `make()` method to use Nova's tab system
- **Translatable.php**: Updated class check to use `Laravel\Nova\Tabs\TabsGroup`
- **TranslatableFields.php**: Removed obsolete eminiarts/tabs check

## Test Plan
- [x] Verify PHP syntax is valid for all modified files
- [x] Confirm no remaining references to eminiarts/tabs package
- [ ] Test tab functionality in Nova admin interface
- [ ] Verify translatable field filtering still works correctly

Fixes #331