### PR TITLE
Fix N+1 query issue in getByTranslatedSlug method

### DIFF
--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -575,6 +575,7 @@ trait Translatable
             ->where('source_field', $slug_column)
             ->where('translated_value', $slug)
             ->where('translatable_type', self::class)
+            ->with('translatable')
             ->first();
 
         if ($translation) {


### PR DESCRIPTION
## Summary
- Fixed N+1 query issue in `getByTranslatedSlug` method by adding eager loading
- Added `->with('translatable')` to prevent additional database queries when accessing the translatable relationship

## Changes
- Modified `src/Traits/Translatable.php` to include eager loading in the query

## Test plan
- [x] Verified the change loads the translatable relationship upfront
- [x] Confirmed the fix matches the proposed solution in the issue

Resolves #345