### PR TITLE
Fix N+1 query on translatable relationship

### DIFF
--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -20,6 +20,18 @@ trait Translatable
 {
     protected $use_translator = true;
 
+    /**
+     * Initialize the Translatable trait for an instance.
+     * Automatically eager loads the translatable relationship to prevent N+1 queries
+     * when accessing translated attributes on collections of models.
+     */
+    public function initializeTranslatable(): void
+    {
+        if (!in_array('translatable', $this->with)) {
+            $this->with[] = 'translatable';
+        }
+    }
+
     protected $protected_from_translations = [
         'id',
         'created_at',


### PR DESCRIPTION
## Problem

When loading collections of models that use the Translatable trait, translations are loaded per-model instead of being eager loaded, causing N+1 query issues.

## Solution

Add `initializeTranslatable()` method that automatically adds the `translatable` relationship to the model's `$with` array. Laravel calls `initialize{TraitName}()` on every model instantiation, ensuring the relationship is always eager loaded when querying collections.

This is a non-breaking change — the relationship was already being lazy-loaded on first access, this just makes it eager by default.